### PR TITLE
Update Tensorflow Probability to Version 0.13.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,8 +27,8 @@ requirements:
     - numpy >=1.13.3
     - six >=1.10.0
     - decorator
-    - cloudpickle =1.1.1
-    - gast >=0.2,<0.3
+    - cloudpickle =1.3
+    - gast >=0.3.2
     - tensorflow-base >=1.15.0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tensorflow-probability" %}
-{% set version = "0.8.0" %}
+{% set version = "0.13.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/tensorflow/probability/archive/{{ version }}.tar.gz
-  sha256: f6049549f6d6b82962523a6bf61c40c1d0c7ac685f209c0084a6da81dd78181d
+  sha256: 3b36775c593639d7e04776293fd9adb3e34ca1a559b9a4f7e2d42a4b4289021c
   patches:
     - 0001-always-build-release.patch
 
@@ -20,10 +20,10 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3
     - pip
   run:
-    - python
+    - python >=3
     - numpy >=1.13.3
     - six >=1.10.0
     - decorator


### PR DESCRIPTION
1. check the upstream

2. check the pinnings
https://github.com/tensorflow/probability/blob/v0.13.0/setup.py
modified cloudpickle, gast

3. check changelogs
The release notes for version 0.13.0 were reviewed. 
https://github.com/tensorflow/probability/releases/tag/v0.13.0
No breaking changes were mentioned. 

In addition the following tests provided in the documentation were reviewed to ensure that the package has no significant issues. 
https://colab.research.google.com/github/tensorflow/probability/blob/master/tensorflow_probability/examples/jupyter_notebooks/TFP_Release_Notebook_0_13_0.ipynb

4. additional research
https://github.com/conda-forge/tensorflow-probability-feedstock/issues
There are two important open issues related to tensorflow probability
both issues seem to be related to available dependencies

5. verify dev_url
6. verify doc_url

7. added pip to the test section
9. verify the test section
10. additional tests
