### PR TITLE
tensorflow-probability 0.14.0 [fix]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
     - 0001-always-build-release.patch
 
 build:
+  noarch: python
   # dm-tree not available on s390x
   skip: True  # [s390x or py<36]
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: 
     - rm -f BUILD
     - "{{ PYTHON }} -m pip install . --no-deps -vv"
@@ -36,6 +36,9 @@ requirements:
     - cloudpickle >=1.3
     - gast >=0.3.2  # For autobatching
     - dm-tree  # For NumPy/JAX backends (hence, also for prefer_static)
+  run_constrained:
+    # https://github.com/tensorflow/probability/blob/21ce02d10112504632ff9c1d22e5cd93ec24694b/tensorflow_probability/python/__init__.py#L58-L68
+    - tensorflow >=2.6
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,23 +12,24 @@ source:
     - 0001-always-build-release.patch
 
 build:
-  noarch: python
+  # dm-tree not available on s390x
+  skip: True  # [s390x or py<36]
   number: 1
   script: 
     - rm -f BUILD
-    - "{{ PYTHON }} -m pip install . --no-deps -vv"
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:
-    - m2-patch # [win]
-    - patch  # [not win]
+    - m2-patch  # [win]
+    - patch     # [not win]
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools
     - wheel
   run:
-    - python >=3.6
+    - python
     - absl-py
     - six >=1.10.0
     - numpy >=1.13.3


### PR DESCRIPTION
tensorflow-probability 0.14.0 [fix]

**Destination channel:** defaults

### Links

- [PKG-5424]
- https://github.com/tensorflow/probability/blob/v0.14.0/

### Explanation of changes:

- This version of `tensorflow-probability` requires `tensorflow >=2.6`. This constraint should be in `run_constrained`. See https://github.com/tensorflow/probability/blob/21ce02d10112504632ff9c1d22e5cd93ec24694b/tensorflow_probability/python/__init__.py#L58-L68


[PKG-5424]: https://anaconda.atlassian.net/browse/PKG-5424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ