### PR TITLE
tensorflow-probability 0.24.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,8 @@ requirements:
   run_constrained:
     # https://github.com/tensorflow/probability/blob/21ce02d10112504632ff9c1d22e5cd93ec24694b/tensorflow_probability/python/__init__.py#L58-L68
     - tensorflow >=2.16
+    - tensorflow-datasets >=2.2.0
+    - tf-keras >=2.16
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tensorflow-probability" %}
-{% set version = "0.14.0" %}
+{% set version = "0.24.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/tensorflow/probability/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 54fe9a9cbfee5d02a561c92a730eb29166fa757084b9ccb3f700de42ddeafcfb
+  sha256: 3d75418cef09ea357ee879347133ab784fe4637a5ba251a8e06ef930dd970a3e
   patches:
     - 0001-always-build-release.patch
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,7 @@ requirements:
     - dm-tree  # For NumPy/JAX backends (hence, also for prefer_static)
   run_constrained:
     # https://github.com/tensorflow/probability/blob/21ce02d10112504632ff9c1d22e5cd93ec24694b/tensorflow_probability/python/__init__.py#L58-L68
-    - tensorflow >=2.6
+    - tensorflow >=2.16
 
 test:
   imports:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-2265](https://anaconda.atlassian.net/browse/PKG-2265)
- [Upstream repository](https://github.com/tensorflow/probability/tree/v0.24.0)
- [Upstream changelog/diff](https://github.com/tensorflow/probability/releases)

### Explanation of changes:

- Update version and sha256
- Update tensorflow version


[PKG-2265]: https://anaconda.atlassian.net/browse/PKG-2265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ